### PR TITLE
Add `extern` to ast expr tombstone fastly main

### DIFF
--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -184,7 +184,7 @@ struct ast {
 	struct ast_expr *expr;
 };
 
-struct ast_expr *ast_expr_tombstone;
+extern struct ast_expr *ast_expr_tombstone;
 
 struct ast *
 ast_new(void);


### PR DESCRIPTION
This is a backport of #239 to the fastly private mirror for testing.

~DO NOT MERGE.~

edit: Preferring to merge this, rather than to update to the current upstream main.