### PR TITLE
Update fastly libfsm for memory usage fix

### DIFF
--- a/src/libfsm/print/ir.h
+++ b/src/libfsm/print/ir.h
@@ -85,7 +85,11 @@ struct ir_state {
 		} error;
 
 		struct {
-			unsigned to[FSM_SIGMA_COUNT];
+			/* Note: This is allocated separately, to avoid
+			 * making the union significantly larger. */
+			struct ir_state_table {
+				unsigned to[FSM_SIGMA_COUNT];
+			} *table;
 		} table;
 	} u;
 };


### PR DESCRIPTION
Sync one more upstream change -- this reduces runtime memory usage, which is necessary to successfully compile master vcl.