### PR TITLE
Update for missing <re/literal.h> header

### DIFF
--- a/include/re/Makefile
+++ b/include/re/Makefile
@@ -1,4 +1,6 @@
 .include "../../share/mk/top.mk"
 
-STAGE_COPY += include/re/re.h include/re/strings.h
+STAGE_COPY += include/re/re.h
+STAGE_COPY += include/re/strings.h
+STAGE_COPY += include/re/literal.h
 


### PR DESCRIPTION
I just missed adding this to the install target, so we didn't get it in the previous sync from main, #15.