### PR TITLE
Update for escaping ? to avoid emitting trigraphs

### DIFF
--- a/src/print/c.c
+++ b/src/print/c.c
@@ -80,9 +80,11 @@ c_escputc_str(FILE *f, const struct fsm_options *opt, char c)
 	 * Escaping '/' here is a lazy way to avoid keeping state when
 	 * emitting '*', '/', since this is used to output example strings
 	 * inside comments.
+	 *
+	 * Escaping '?' is a cheap way to avoid accidentally emitting trigraphs.
 	 */
 
-	if (!isprint((unsigned char) c) || c == '/') {
+	if (!isprint((unsigned char) c) || c == '/' || c == '?') {
 		return fprintf(f, "\\%03o", (unsigned char) c);
 	}
 

--- a/tests/retest/tests_2.tst
+++ b/tests/retest/tests_2.tst
@@ -16,3 +16,10 @@ R pcre
 +
 -xyz
 
+# avoid generating trigraphs (!) in strncmp()/memcmp() for inlined strings
+~^abc\?\?-$
++abc??-
+-abc???-
+-abc~
+-abc
+


### PR DESCRIPTION
This brings us up to date as of https://github.com/katef/libfsm/pull/433

This was found during bootstrap, and there's a corresponding PR fastly/vcc-see#33 to catch this earlier, during CI, instead.