### PR TITLE
cdata codegen with eager outputs, part 2

### DIFF
--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -105,10 +105,12 @@ fsm_exec(const struct fsm *fsm,
 
 	/* TODO: pass struct of callbacks to call during each event; transitions etc */
 
+#if EXPENSIVE_CHECKS
 	if (!fsm_all(fsm, fsm_isdfa)) {
 		errno = EINVAL;
 		return -1;
 	}
+#endif
 
 	if (!fsm_getstart(fsm, &state)) {
 		errno = EINVAL;

--- a/src/libfsm/print/cdata.c
+++ b/src/libfsm/print/cdata.c
@@ -604,21 +604,21 @@ generate_interpreter(FILE *f, const struct cdata_config *config, const struct fs
 
 		switch (opt->ambig) {
 		case AMBIG_NONE:
+			fprintf(f,
+			    "\t\t(void)endid_base;\n");
 			break;
 
 		case AMBIG_ERROR:
 		case AMBIG_EARLIEST:
 			fprintf(f,
 			    "\t\t*id = *endid_base;\n"
-			    "\t\t(void)endid_count;\n"
-			    "\t}\n");
+			    "\t\t(void)endid_count;\n");
 			break;
 
 		case AMBIG_MULTIPLE:
 			fprintf(f,
 			    "\t\t*%s = endid_base;\n"
-			    "\t\t*%s = endid_count;\n"
-			    "\t}\n",
+			    "\t\t*%s = endid_count;\n",
 			    /* TODO: rename these to endid_ids and endid_count?
 			     * That will be an interface change. */
 			    "ids", "count");
@@ -628,6 +628,9 @@ generate_interpreter(FILE *f, const struct cdata_config *config, const struct fs
 			assert(!"unreached");
 			abort();
 		}
+
+		fprintf(f,
+		    "\t}\n");
 	}
 
 	/* If the end state has eager_outputs, set their flags. */


### PR DESCRIPTION
- Add an `EXPENSIVE_CHECKS` wrapper to fsm_exec, this means minutes vs. **HOURS** for this build.
- Fix the codegen handling for `AMBIG_MULTI` vs. `AMBIG_NONE`, etc. This fixes a warning and bad bracing.