### PR TITLE
Fix CI To Run on Ubuntu-22.04 For Clang 14.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   checkout:
     name: "Checkout"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Cache checkout
@@ -44,7 +44,7 @@ jobs:
 
   pcre_suite:
     name: "Import PCRE suite"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ build ] # for cvtpcre
 
     steps:
@@ -130,7 +130,7 @@ jobs:
 
   build:
     name: "Build ${{ matrix.san }} ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ubuntu-22.04
     needs: [ checkout ]
 
     strategy:
@@ -216,7 +216,7 @@ jobs:
   # of the build during CI, even if we don't run that during tests.
   test_makefiles:
     name: "Test (Makefiles) ${{ matrix.make }} ${{ matrix.os }} ${{ matrix.debug }}"
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ubuntu-22.04
     needs: [ checkout, build ]
 
     strategy:
@@ -301,7 +301,7 @@ jobs:
 
   test_san:
     name: "Test (Sanitizers) ${{ matrix.san }} ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ubuntu-22.04
     needs: [ build ]
 
     strategy:
@@ -362,7 +362,7 @@ jobs:
 
   test_fuzz:
     name: "Fuzz (mode ${{ matrix.mode }}) ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5 # this should never be reached, it's a safeguard for bugs in the fuzzer itself
     needs: [ build ]
 
@@ -470,7 +470,7 @@ jobs:
 
   test_pcre:
     name: "Test (PCRE suite) ${{ matrix.lang }} ${{ matrix.san }} ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ubuntu-22.04
     needs: [ pcre_suite ] # and also build, but pcre_suite gives us that
 
     strategy:
@@ -531,7 +531,7 @@ jobs:
 
   docs:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ checkout ]
 
     env:
@@ -582,7 +582,7 @@ jobs:
 
   install:
     name: Install
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ build, docs ]
 
     env:
@@ -643,7 +643,7 @@ jobs:
 
   fpm:
     name: Package ${{ matrix.pkg }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ install ]
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,10 @@ jobs:
 
   pcre_suite:
     name: "Import PCRE suite"
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04 ]
     needs: [ build ] # for cvtpcre
 
     steps:
@@ -71,7 +74,7 @@ jobs:
       id: cache-cvtpcre
       with:
         path: ${{ env.cvtpcre }}
-        key: cvtpcre-bmake-ubuntu-gcc-DEBUG-AUSAN-${{ github.sha }}-${{ env.pcre2 }}
+        key: cvtpcre-bmake-${{ matrix.os }}-gcc-DEBUG-AUSAN-${{ github.sha }}-${{ env.pcre2 }}
 
     - name: Fetch build
       if: steps.cache-cvtpcre.outputs.cache-hit != 'true'
@@ -79,7 +82,7 @@ jobs:
       id: cache-build
       with:
         path: ${{ env.build }}
-        key: build-bmake-ubuntu-gcc-DEBUG-AUSAN-${{ github.sha }} # arbitary build, just for cvtpcre
+        key: build-bmake-${{ matrix.os }}-gcc-DEBUG-AUSAN-${{ github.sha }} # arbitrary build, just for cvtpcre
 
     - name: Convert PCRE suite
       if: steps.cache-cvtpcre.outputs.cache-hit != 'true'
@@ -130,14 +133,14 @@ jobs:
 
   build:
     name: "Build ${{ matrix.san }} ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     needs: [ checkout ]
 
     strategy:
       fail-fast: true
       matrix:
         san: [ NO_SANITIZER, AUSAN, MSAN, EFENCE, FUZZER ] # NO_SANITIZER=1 is a no-op
-        os: [ ubuntu ]
+        os: [ ubuntu-22.04 ]
         cc: [ clang, gcc ]
         make: [ bmake ] # we test makefiles separately
         debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
@@ -169,7 +172,7 @@ jobs:
         key: build-${{ matrix.make }}-${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.debug }}-${{ matrix.san }}-${{ github.sha }}
 
     - name: Dependencies (Ubuntu)
-      if: matrix.os == 'ubuntu' && steps.cache-build.outputs.cache-hit != 'true'
+      if: matrix.os == 'ubuntu-22.04' && steps.cache-build.outputs.cache-hit != 'true'
       run: |
         uname -a
         sudo apt-get install bmake electric-fence
@@ -216,14 +219,14 @@ jobs:
   # of the build during CI, even if we don't run that during tests.
   test_makefiles:
     name: "Test (Makefiles) ${{ matrix.make }} ${{ matrix.os }} ${{ matrix.debug }}"
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     needs: [ checkout, build ]
 
     strategy:
       fail-fast: false
       matrix:
         san: [ NO_SANITIZER ] # NO_SANITIZER=1 is a no-op
-        os: [ ubuntu ]
+        os: [ ubuntu-22.04 ]
         cc: [ clang ]
         make: [ bmake, pmake ]
         debug: [ EXPENSIVE_CHECKS, DEBUG, RELEASE ] # RELEASE=1 is a no-op
@@ -258,7 +261,7 @@ jobs:
       run: find ${{ env.wc }} -type f -name '*.c' | sort -r | head -5 | xargs touch
 
     - name: Dependencies (Ubuntu)
-      if: matrix.os == 'ubuntu'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         uname -a
         sudo apt-get install pmake bmake pcregrep
@@ -301,14 +304,14 @@ jobs:
 
   test_san:
     name: "Test (Sanitizers) ${{ matrix.san }} ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     needs: [ build ]
 
     strategy:
       fail-fast: false
       matrix:
         san: [ AUSAN, MSAN, EFENCE ]
-        os: [ ubuntu ]
+        os: [ ubuntu-22.04 ]
         cc: [ clang, gcc ]
         make: [ bmake ]
         debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
@@ -329,7 +332,7 @@ jobs:
         key: checkout-${{ github.sha }}
 
     - name: Dependencies (Ubuntu)
-      if: matrix.os == 'ubuntu'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         uname -a
         sudo apt-get install bmake pcregrep electric-fence
@@ -362,7 +365,7 @@ jobs:
 
   test_fuzz:
     name: "Fuzz (mode ${{ matrix.mode }}) ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 5 # this should never be reached, it's a safeguard for bugs in the fuzzer itself
     needs: [ build ]
 
@@ -370,7 +373,7 @@ jobs:
       fail-fast: false
       matrix:
         san: [ FUZZER ]
-        os: [ ubuntu ]
+        os: [ ubuntu-22.04 ]
         cc: [ clang ]
         make: [ bmake ]
         debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
@@ -388,7 +391,7 @@ jobs:
         key: checkout-${{ github.sha }}
 
     - name: Dependencies (Ubuntu)
-      if: matrix.os == 'ubuntu'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         uname -a
         sudo apt-get install bmake
@@ -470,14 +473,14 @@ jobs:
 
   test_pcre:
     name: "Test (PCRE suite) ${{ matrix.lang }} ${{ matrix.san }} ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     needs: [ pcre_suite ] # and also build, but pcre_suite gives us that
 
     strategy:
       fail-fast: false
       matrix:
         san: [ AUSAN, MSAN, EFENCE ]
-        os: [ ubuntu ]
+        os: [ ubuntu-22.04 ]
         cc: [ clang, gcc ]
         make: [ bmake ]
         debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
@@ -492,7 +495,7 @@ jobs:
 
     steps:
     - name: Dependencies (Ubuntu)
-      if: matrix.os == 'ubuntu' && matrix.san == 'EFENCE'
+      if: matrix.os == 'ubuntu-22.04' && matrix.san == 'EFENCE'
       run: |
         uname -a
         sudo apt-get install electric-fence
@@ -506,7 +509,7 @@ jobs:
         ${{ matrix.cc }} --version
 
     - name: Dependencies (Ubuntu/Go)
-      if: matrix.os == 'ubuntu' && (matrix.lang == 'go' || matrix.lang == 'goasm')
+      if: matrix.os == 'ubuntu-22.04' && (matrix.lang == 'go' || matrix.lang == 'goasm')
       run: |
         uname -a
         sudo apt-get install golang
@@ -524,7 +527,7 @@ jobs:
       id: cache-cvtpcre
       with:
         path: ${{ env.cvtpcre }}
-        key: cvtpcre-bmake-ubuntu-gcc-DEBUG-AUSAN-${{ github.sha }}-${{ env.pcre2 }}
+        key: cvtpcre-bmake-${{ matrix.os }}-gcc-DEBUG-AUSAN-${{ github.sha }}-${{ env.pcre2 }}
 
     - name: Run PCRE suite (${{ matrix.lang }})
       run: CC=${{ matrix.cc }} ./${{ env.build }}/bin/retest -O1 -l ${{ matrix.lang }} ${{ env.cvtpcre }}/*.tst
@@ -587,7 +590,7 @@ jobs:
 
     env:
       san: NO_SANITIZER # NO_SANITIZER=1 is a no-op
-      os: ubuntu
+      os: ubuntu-22.04
       cc: clang
       make: bmake
       debug: RELEASE # RELEASE=1 is a no-op
@@ -601,7 +604,7 @@ jobs:
         key: prefix-${{ env.make }}-${{ env.os }}-${{ env.cc }}-${{ env.debug }}-${{ env.san }}-${{ github.sha }}
 
     - name: Dependencies (Ubuntu)
-      if: env.os == 'ubuntu' && steps.cache-prefix.outputs.cache-hit != 'true'
+      if: env.os == 'ubuntu-22.04' && steps.cache-prefix.outputs.cache-hit != 'true'
       run: |
         uname -a
         sudo apt-get install bmake
@@ -648,7 +651,7 @@ jobs:
 
     env:
       san: NO_SANITIZER # NO_SANITIZER=1 is a no-op
-      os: ubuntu
+      os: ubuntu-22.04
       cc: clang
       make: bmake
       debug: RELEASE # RELEASE=1 is a no-op
@@ -661,7 +664,7 @@ jobs:
 
     steps:
     - name: Dependencies (Ubuntu)
-      if: env.os == 'ubuntu'
+      if: env.os == 'ubuntu-22.04'
       run: |
         uname -a
         sudo gem install --no-document fpm


### PR DESCRIPTION
CI has been failing because GitHub Updated `ubuntu-latest` to 24.04 which includes a bleeding edge `clang` version (`18.1.3`) and has been failing since. 

This PR keeps the `matrix.os` so we can add new versions to the test suite as necessary (but currently only ubuntu is being ran) but locks the ubuntu version to 22.04 until we can work on updating this to 24.04.  