### PR TITLE
Stray const in generated code

### DIFF
--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -584,7 +584,7 @@ fsm_print_c(FILE *f,
 		case AMBIG_ERROR:
 		case AMBIG_EARLIEST:
 			fprintf(f, ",\n");
-			fprintf(f, "\tconst unsigned *id");
+			fprintf(f, "\tunsigned *id");
 			break;
 
 		case AMBIG_MULTIPLE:

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -588,7 +588,7 @@ fsm_print_vmc(FILE *f,
 		case AMBIG_ERROR:
 		case AMBIG_EARLIEST:
 			fprintf(f, ",\n");
-			fprintf(f, "\tconst unsigned *id");
+			fprintf(f, "\tunsigned *id");
 			break;
 
 		case AMBIG_MULTIPLE:


### PR DESCRIPTION
Cherry-picking the fix from katef/libfsm#511

I'm grabbing this in order to decouple the work I have depending on this fix from the essentially unrelated work of updating fastly/libfsm